### PR TITLE
Node content and graph title use C# type names

### DIFF
--- a/src/Autofac.Diagnostics.DotGraph/ActivatorExtensions.cs
+++ b/src/Autofac.Diagnostics.DotGraph/ActivatorExtensions.cs
@@ -23,7 +23,7 @@ namespace Autofac.Diagnostics.DotGraph
             // There is a similar class in the Autofac core library but
             // this gives us full control over display in the graph as
             // well as not requiring DisplayName be part of the public API.
-            var fullName = activator?.LimitType.FullName ?? "";
+            var fullName = activator?.LimitType.CSharpName() ?? "";
             return activator is DelegateActivator ?
                 $"λ:{fullName}" :
                 fullName;

--- a/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
+++ b/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.CodeDom" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Autofac.Diagnostics.DotGraph/DotDiagnosticTracer.cs
+++ b/src/Autofac.Diagnostics.DotGraph/DotDiagnosticTracer.cs
@@ -65,7 +65,7 @@ namespace Autofac.Diagnostics.DotGraph
             }
 
             var builder = _operationBuilders.GetOrAdd(data.Operation, k => new DotGraphBuilder());
-            builder.OnOperationStart(data.Operation.InitiatingRequest?.Service.Description);
+            builder.OnOperationStart(data.Operation.InitiatingRequest?.Service.GraphDisplayName());
         }
 
         /// <inheritdoc/>

--- a/src/Autofac.Diagnostics.DotGraph/ResolveRequestNode.cs
+++ b/src/Autofac.Diagnostics.DotGraph/ResolveRequestNode.cs
@@ -126,7 +126,7 @@ namespace Autofac.Diagnostics.DotGraph
             stringBuilder.StartNode(Id, shape, Success);
             foreach (var service in Services.Keys)
             {
-                stringBuilder.AppendServiceRow(service.Description, Services[service]);
+                stringBuilder.AppendServiceRow(service.GraphDisplayName(), Services[service]);
             }
 
             stringBuilder.AppendTableRow(TracerMessages.ComponentDisplay, Component);
@@ -144,12 +144,12 @@ namespace Autofac.Diagnostics.DotGraph
             if (Instance is object &&
                 (Services.Count != 1 || !(Services.First().Key is IServiceWithType swt) || swt.ServiceType != Instance.GetType()))
             {
-                stringBuilder.AppendTableRow(TracerMessages.InstanceDisplay, Instance.GetType().FullName);
+                stringBuilder.AppendTableRow(TracerMessages.InstanceDisplay, Instance.GetType().CSharpName());
             }
 
             if (Exception is object)
             {
-                stringBuilder.AppendTableErrorRow(Exception.GetType().FullName, Exception.Message);
+                stringBuilder.AppendTableErrorRow(Exception.GetType().CSharpName(), Exception.Message);
             }
 
             stringBuilder.EndNode();
@@ -159,7 +159,10 @@ namespace Autofac.Diagnostics.DotGraph
                 var destination = allRequests[edge.Request];
                 var edgeId = destination.Id.NodeId() + ":" + destination.Services[edge.Service].NodeId();
 
-                // Shorter type name for line descriptions where possible.
+                // Shorter type name for line descriptions where possible. Using
+                // the type name here rather than the C# name because C# will
+                // include the namespace and will be longer than raw type name.
+                // It will still be "pretty printed" in the individual nodes.
                 var description = edge.Service is IServiceWithType edgeSwt ? edgeSwt.ServiceType.Name : edge.Service.Description;
                 stringBuilder.ConnectNodes(Id.NodeId(), edgeId, description, !destination.Success);
             }

--- a/src/Autofac.Diagnostics.DotGraph/ServiceExtensions.cs
+++ b/src/Autofac.Diagnostics.DotGraph/ServiceExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Core;
+
+namespace Autofac.Diagnostics.DotGraph
+{
+    /// <summary>
+    /// Extension methods for building DOT graph components from services.
+    /// </summary>
+    internal static class ServiceExtensions
+    {
+        /// <summary>
+        /// Gets the display name for a service that should be used in a graph.
+        /// </summary>
+        /// <param name="service">The service for which a display name should be retrieved.</param>
+        /// <returns>A <see cref="string"/> with a human-readable, pretty-printed display name for use in a graph node or label.</returns>
+        public static string GraphDisplayName(this Service service)
+        {
+            return service switch
+            {
+                IServiceWithType swt => swt.ServiceType.CSharpName(),
+                _ => service.Description
+            };
+        }
+    }
+}

--- a/src/Autofac.Diagnostics.DotGraph/TypeExtensions.cs
+++ b/src/Autofac.Diagnostics.DotGraph/TypeExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.CodeDom;
+using Microsoft.CSharp;
+
+namespace Autofac.Diagnostics.DotGraph
+{
+    /// <summary>
+    /// Extension methods for building DOT graph components from types.
+    /// </summary>
+    internal static class TypeExtensions
+    {
+        /// <summary>
+        /// Gets the C# code text for a given type. This is effectively a "pretty printed" version
+        /// of the type name.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> for which the C# name should be generated.</param>
+        /// <returns>
+        /// The name of the <paramref name="type"/> as it would be seen if one was
+        /// writing C# code referencing the type.
+        /// </returns>
+        public static string CSharpName(this Type type)
+        {
+            using var provider = new CSharpCodeProvider();
+            var typeRef = new CodeTypeReference(type);
+            return provider.GetTypeOutput(typeRef);
+        }
+    }
+}

--- a/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
+++ b/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Autofac.Diagnostics.DotGraph.Test
+{
+    public class ComplexGraphTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ComplexGraphTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public interface IService1
+        {
+        }
+
+        public interface IService2
+        {
+        }
+
+        public interface IService3
+        {
+        }
+
+        public interface IHandler<T>
+        {
+        }
+
+        [Fact]
+        public void GeneratesComplexGraph()
+        {
+            using var container = BuildGraphContainer();
+
+            var tracer = new DotDiagnosticTracer();
+            string result = null;
+            tracer.OperationCompleted += (sender, args) =>
+            {
+                result = args.TraceContent;
+                _output.WriteLine(result);
+            };
+            container.SubscribeToDiagnostics(tracer);
+
+            using var scope = container.BeginLifetimeScope();
+            scope.Resolve<IHandler<string>>();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void LabelPosition()
+        {
+            using var container = BuildGraphContainer();
+
+            var tracer = new DotDiagnosticTracer();
+            string result = null;
+            tracer.OperationCompleted += (sender, args) =>
+            {
+                result = args.TraceContent;
+            };
+            container.SubscribeToDiagnostics(tracer);
+
+            using var scope = container.BeginLifetimeScope();
+            scope.Resolve<IHandler<string>>();
+
+            // Label should be at the top.
+            Assert.Contains("labelloc=t", result);
+        }
+
+        [Fact]
+        public void TypeNamesArePrettyPrinted()
+        {
+            using var container = BuildGraphContainer();
+
+            var tracer = new DotDiagnosticTracer();
+            string result = null;
+            tracer.OperationCompleted += (sender, args) =>
+            {
+                result = args.TraceContent;
+            };
+            container.SubscribeToDiagnostics(tracer);
+
+            using var scope = container.BeginLifetimeScope();
+            scope.Resolve<IHandler<string>>();
+
+            // Label should be pretty-printed.
+            Assert.Contains("label=<Autofac.Diagnostics.DotGraph.Test.ComplexGraphTests.IHandler&lt;string&gt;>;", result);
+
+            // No raw type names.
+            Assert.DoesNotContain("`1", result);
+            Assert.DoesNotContain("Culture=neutral", result);
+        }
+
+        private static IContainer BuildGraphContainer()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterGeneric(typeof(Handler<>)).As(typeof(IHandler<>));
+            builder.RegisterType<Component1>().As<IService1>();
+            builder.RegisterType<Component2>().As<IService2>().SingleInstance();
+            builder.Register(ctx => new Component3()).As<IService3>();
+            builder.RegisterDecorator<Component3Decorator, IService3>();
+            return builder.Build();
+        }
+
+        public class Component1 : IService1
+        {
+            public Component1(IService2 service2, IService3 service3)
+            {
+                Service2 = service2 ?? throw new ArgumentNullException(nameof(service2));
+                Service3 = service3 ?? throw new ArgumentNullException(nameof(service3));
+            }
+
+            public IService2 Service2 { get; }
+
+            public IService3 Service3 { get; }
+        }
+
+        public class Component2 : IService2
+        {
+            public Component2(IService3 service3)
+            {
+                Service3 = service3 ?? throw new ArgumentNullException(nameof(service3));
+            }
+
+            public IService3 Service3 { get; }
+        }
+
+        public class Component3 : IService3
+        {
+        }
+
+        public class Component3Decorator : IService3
+        {
+            public Component3Decorator(IService3 decorated)
+            {
+                Decorated = decorated ?? throw new ArgumentNullException(nameof(decorated));
+            }
+
+            public IService3 Decorated { get; }
+        }
+
+        public class Handler<T> : IHandler<T>
+        {
+            public Handler(IService1 service1, IService2 service2)
+            {
+                Service1 = service1 ?? throw new ArgumentNullException(nameof(service1));
+                Service2 = service2 ?? throw new ArgumentNullException(nameof(service2));
+            }
+
+            public IService1 Service1 { get; }
+
+            public IService2 Service2 { get; }
+        }
+    }
+}

--- a/test/Autofac.Diagnostics.DotGraph.Test/DotDiagnosticTracerTests.cs
+++ b/test/Autofac.Diagnostics.DotGraph.Test/DotDiagnosticTracerTests.cs
@@ -35,7 +35,7 @@ namespace Autofac.Diagnostics.DotGraph.Test
 
             container.Resolve<string>();
 
-            Assert.Contains("λ:System.String", lastOpResult);
+            Assert.Contains("λ:string", lastOpResult);
             Assert.StartsWith("digraph G {", lastOpResult);
             Assert.EndsWith("}", lastOpResult.Trim());
         }


### PR DESCRIPTION
Resolves #2.

Switching to use the CSharpCodeProvider to generate the name as it'd appear in C# for a "pretty-printed" version of the type name. This shortens all type names a little by removing the assembly qualified name info; but also makes generics much easier to read since there's no nested fully qualified names.

Node edge labels still use a short name to avoid putting the namespace on node edges; in actual node blocks and on the graph title is where the C# is applied. This seemed to be a good balance between "too much data" (the node edges stay short, if possibly inconsistent in the case of generics) and readability (nodes proper and title use the prettier code view).

![Using C# names in nodes and title](https://user-images.githubusercontent.com/1156571/90417545-b40a0e80-e068-11ea-8f69-88c65b52880f.png)