### PR TITLE
Visually indicate disconnected operations

### DIFF
--- a/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
+++ b/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
@@ -38,7 +38,7 @@
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.0.0-v6-01101" />
+    <PackageReference Include="Autofac" Version="6.0.0-develop-01132" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Diagnostics.DotGraph/DotGraphBuilder.cs
+++ b/src/Autofac.Diagnostics.DotGraph/DotGraphBuilder.cs
@@ -51,9 +51,15 @@ namespace Autofac.Diagnostics.DotGraph
         /// Adds information about the operation available at operation start.
         /// </summary>
         /// <param name="service">The display name of the service being resolved in this operation.</param>
-        public void OnOperationStart(string? service)
+        /// <param name="sequenceNumber">
+        /// A <see cref="long"/> indicating a basic ordering of resolve operations to
+        /// enable some correlation between a parent operation and child operations that
+        /// involve service location.
+        /// </param>
+        public void OnOperationStart(string? service, long sequenceNumber)
         {
             Operation.Service = service;
+            Operation.SequenceNumber = sequenceNumber;
         }
 
         /// <summary>

--- a/src/Autofac.Diagnostics.DotGraph/DotStringExtensions.cs
+++ b/src/Autofac.Diagnostics.DotGraph/DotStringExtensions.cs
@@ -35,17 +35,22 @@ namespace Autofac.Diagnostics.DotGraph
         /// <see langword="true"/> to indicate the operation was successful; <see langword="false"/> to
         /// highlight the operation as a failure path.
         /// </param>
+        /// <param name="deferred">
+        /// <see langword="true"/> to indicate the node may contain the start of a deferred service
+        /// resolution (e.g., it's a service location waiting to happen); <see langword="false"/> if not.
+        /// </param>
         /// <returns>
         /// The <paramref name="stringBuilder" /> for continued writing.
         /// </returns>
-        public static StringBuilder StartNode(this StringBuilder stringBuilder, Guid id, string shape, bool success)
+        public static StringBuilder StartNode(this StringBuilder stringBuilder, Guid id, string shape, bool success, bool deferred)
         {
             stringBuilder.AppendFormat(
                 CultureInfo.CurrentCulture,
-                "{0} [shape={1},{2}label=<",
+                "{0} [shape={1},{2}{3}label=<",
                 id.NodeId(),
                 shape,
-                success ? null : "penwidth=3,color=red,");
+                success ? null : "penwidth=3,color=red,",
+                deferred ? "style=dotted," : null);
             stringBuilder.AppendLine();
             stringBuilder.AppendLine("<table border='0' cellborder='0' cellspacing='0'>");
             return stringBuilder;

--- a/src/Autofac.Diagnostics.DotGraph/OperationNode.cs
+++ b/src/Autofac.Diagnostics.DotGraph/OperationNode.cs
@@ -54,7 +54,8 @@ namespace Autofac.Diagnostics.DotGraph
                 stringBuilder.Append("</b>");
             }
 
-            stringBuilder.Append("<br/><font point-size=\"8\">Operation #");
+            stringBuilder.Append("<br/><font point-size=\"8\">");
+            stringBuilder.Append(TracerMessages.OperationNumber);
             stringBuilder.Append(SequenceNumber);
             stringBuilder.Append("</font>>;");
             stringBuilder.AppendLine();

--- a/src/Autofac.Diagnostics.DotGraph/OperationNode.cs
+++ b/src/Autofac.Diagnostics.DotGraph/OperationNode.cs
@@ -23,6 +23,17 @@ namespace Autofac.Diagnostics.DotGraph
         public bool Success { get; set; }
 
         /// <summary>
+        /// Gets or sets the operation sequence number for resolve operation ordering.
+        /// </summary>
+        /// <value>
+        /// A <see cref="long"/> indicating the general sequence in which the resolve
+        /// operation reached a terminal state (success or failure). This can be used
+        /// to roughly correlate disconnected resolve operations where service location
+        /// may be taking place.
+        /// </value>
+        public long SequenceNumber { get; set; }
+
+        /// <summary>
         /// Serializes the top-level operation data to the graph.
         /// </summary>
         /// <param name="stringBuilder">
@@ -43,7 +54,9 @@ namespace Autofac.Diagnostics.DotGraph
                 stringBuilder.Append("</b>");
             }
 
-            stringBuilder.Append(">;");
+            stringBuilder.Append("<br/><font point-size=\"8\">Operation #");
+            stringBuilder.Append(SequenceNumber);
+            stringBuilder.Append("</font>>;");
             stringBuilder.AppendLine();
             stringBuilder.AppendLine("labelloc=t");
         }

--- a/src/Autofac.Diagnostics.DotGraph/ResolveRequestNode.cs
+++ b/src/Autofac.Diagnostics.DotGraph/ResolveRequestNode.cs
@@ -123,7 +123,9 @@ namespace Autofac.Diagnostics.DotGraph
         public void ToString(StringBuilder stringBuilder, RequestDictionary allRequests)
         {
             var shape = DecoratorTarget == null ? "component" : "box3d";
-            stringBuilder.StartNode(Id, shape, Success);
+            var allServiceTypes = Services.Keys.OfType<IServiceWithType>().Select(s => s.ServiceType).ToArray();
+            var deferred = allServiceTypes.Contains(typeof(ILifetimeScope)) || allServiceTypes.Contains(typeof(IComponentContext));
+            stringBuilder.StartNode(Id, shape, Success, deferred);
             foreach (var service in Services.Keys)
             {
                 stringBuilder.AppendServiceRow(service.GraphDisplayName(), Services[service]);
@@ -150,6 +152,11 @@ namespace Autofac.Diagnostics.DotGraph
             if (Exception is object)
             {
                 stringBuilder.AppendTableErrorRow(Exception.GetType().CSharpName(), Exception.Message);
+            }
+
+            if (deferred)
+            {
+                stringBuilder.AppendTableRow(TracerMessages.DeferredOperation);
             }
 
             stringBuilder.EndNode();

--- a/src/Autofac.Diagnostics.DotGraph/TracerMessages.resx
+++ b/src/Autofac.Diagnostics.DotGraph/TracerMessages.resx
@@ -120,6 +120,9 @@
   <data name="ComponentDisplay" xml:space="preserve">
     <value>Component: {0}</value>
   </data>
+  <data name="DeferredOperation" xml:space="preserve">
+    <value>Possible deferred resolve operation / service location</value>
+  </data>
   <data name="InstanceDisplay" xml:space="preserve">
     <value>Instance: {0}</value>
   </data>

--- a/src/Autofac.Diagnostics.DotGraph/TracerMessages.resx
+++ b/src/Autofac.Diagnostics.DotGraph/TracerMessages.resx
@@ -126,6 +126,9 @@
   <data name="InstanceDisplay" xml:space="preserve">
     <value>Instance: {0}</value>
   </data>
+  <data name="OperationNumber" xml:space="preserve">
+    <value>Operation #</value>
+  </data>
   <data name="TargetDisplay" xml:space="preserve">
     <value>Target: {0}</value>
   </data>

--- a/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
+++ b/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
@@ -89,7 +89,7 @@ namespace Autofac.Diagnostics.DotGraph.Test
             scope.Resolve<IHandler<string>>();
 
             // Label should be pretty-printed.
-            Assert.Contains("label=<Autofac.Diagnostics.DotGraph.Test.ComplexGraphTests.IHandler&lt;string&gt;>;", result);
+            Assert.Contains("label=<Autofac.Diagnostics.DotGraph.Test.ComplexGraphTests.IHandler&lt;string&gt;", result);
 
             // No raw type names.
             Assert.DoesNotContain("`1", result);

--- a/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
+++ b/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
@@ -136,12 +136,15 @@ namespace Autofac.Diagnostics.DotGraph.Test
 
         public class Component3Decorator : IService3
         {
-            public Component3Decorator(IService3 decorated)
+            public Component3Decorator(IService3 decorated, ILifetimeScope scope)
             {
                 Decorated = decorated ?? throw new ArgumentNullException(nameof(decorated));
+                Scope = scope ?? throw new ArgumentNullException(nameof(scope));
             }
 
             public IService3 Decorated { get; }
+
+            public ILifetimeScope Scope { get; }
         }
 
         public class Handler<T> : IHandler<T>


### PR DESCRIPTION
Resolves #3.

Anywhere in the graph where an `ILifetimeScope` or `IComponentContext` is resolved, that component is indicated with a dotted line and a note "possible resolve operation" so people realize there may be some additional service location going on that we can't necessarily correlate.

There is a sequence number counter added to the top of the graph so order of operations (based on when the operation started) can be determined to try to help roughly correlate parent/child ops.

Example:

![Example graph with deferred resolve op](https://user-images.githubusercontent.com/1156571/91910049-25e67880-ec63-11ea-8d4a-763ead880a51.png)
