### PR TITLE
Update build for .NET 7, Autofac 7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Ubuntu
 
-version: '1.0.0.{build}'
+version: '1.1.0.{build}'
 
 dotnet_csproj:
-  version_prefix: '1.0.0'
+  version_prefix: '1.1.0'
   patch: true
   file: 'src\**\*.csproj'
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
   "sdk": {
-    "version": "6.0.401",
+    "version": "7.0.200",
     "rollForward": "latestFeature"
-  }
+  },
+  "additionalSdks": [
+    "6.0.406"
+  ]
 }

--- a/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
+++ b/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
@@ -13,11 +13,12 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Packaging -->
@@ -35,7 +36,10 @@
     <EmbedAllSources>true</EmbedAllSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- OmniSharp/VS Code resource generation -->
+    <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
+
   <!-- Disable nullability warnings in netstandard2.0 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
@@ -55,33 +59,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.4.0" />
+    <PackageReference Include="Autofac" Version="7.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.CodeDom" Version="4.7.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
+    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!--
-      Magic embedded resource incantation based on https://github.com/dotnet/msbuild/issues/4751
-
-      The EmbeddedResource entry seems to add the Designer files to Compile, so
-      if you don't first remove them from Compile you get warnings about
-      double-including source.
-    -->
-    <Compile Remove="**/*.Designer.cs" />
-    <EmbeddedResource Update="TracerMessages.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>TracerMessages.Designer.cs</LastGenOutput>
-      <StronglyTypedFileName>TracerMessages.Designer.cs</StronglyTypedFileName>
+  <ItemDefinitionGroup>
+    <EmbeddedResource>
+      <Generator>MSBuild:Compile</Generator>
       <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
+      <StronglyTypedFileName>$(IntermediateOutputPath)%(Filename).Designer.cs</StronglyTypedFileName>
+      <StronglyTypedClassName>%(Filename)</StronglyTypedClassName>
+    </EmbeddedResource>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="TracerMessages.resx">
       <StronglyTypedNamespace>Autofac.Diagnostics.DotGraph</StronglyTypedNamespace>
-      <StronglyTypedClassName>TracerMessages</StronglyTypedClassName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/test/Autofac.Diagnostics.DotGraph.Test/Autofac.Diagnostics.DotGraph.Test.csproj
+++ b/test/Autofac.Diagnostics.DotGraph.Test/Autofac.Diagnostics.DotGraph.Test.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -29,21 +30,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
+++ b/test/Autofac.Diagnostics.DotGraph.Test/ComplexGraphTests.cs
@@ -106,7 +106,7 @@ public class ComplexGraphTests
     }
 
     [SuppressMessage("CA1812", "CA1812", Justification = "Instantiated via reflection.")]
-    private class Component1 : IService1
+    private sealed class Component1 : IService1
     {
         public Component1(IService2 service2, IService3 service3)
         {
@@ -120,7 +120,7 @@ public class ComplexGraphTests
     }
 
     [SuppressMessage("CA1812", "CA1812", Justification = "Instantiated via reflection.")]
-    private class Component2 : IService2
+    private sealed class Component2 : IService2
     {
         public Component2(IService3 service3)
         {
@@ -130,12 +130,12 @@ public class ComplexGraphTests
         public IService3 Service3 { get; }
     }
 
-    private class Component3 : IService3
+    private sealed class Component3 : IService3
     {
     }
 
     [SuppressMessage("CA1812", "CA1812", Justification = "Instantiated via reflection.")]
-    private class Component3Decorator : IService3
+    private sealed class Component3Decorator : IService3
     {
         public Component3Decorator(IService3 decorated, ILifetimeScope scope)
         {
@@ -149,7 +149,7 @@ public class ComplexGraphTests
     }
 
     [SuppressMessage("CA1812", "CA1812", Justification = "Instantiated via reflection.")]
-    private class Handler<T> : IHandler<T>
+    private sealed class Handler<T> : IHandler<T>
     {
         public Handler(IService1 service1, IService2 service2)
         {

--- a/test/Autofac.Diagnostics.DotGraph.Test/DotDiagnosticTracerTests.cs
+++ b/test/Autofac.Diagnostics.DotGraph.Test/DotDiagnosticTracerTests.cs
@@ -235,7 +235,7 @@ public class DotDiagnosticTracerTests
                 ctx.Registration == registration);
     }
 
-    private class TestTracer : DotDiagnosticTracer
+    private sealed class TestTracer : DotDiagnosticTracer
     {
         public void TestWrite(string diagnosticName, object data)
         {
@@ -244,7 +244,7 @@ public class DotDiagnosticTracerTests
     }
 
     [SuppressMessage("CA1812", "CA1812", Justification = "Instantiated via reflection.")]
-    private class Decorator : IService
+    private sealed class Decorator : IService
     {
         public Decorator(IService decorated)
         {
@@ -255,7 +255,7 @@ public class DotDiagnosticTracerTests
     }
 
     [SuppressMessage("CA1812", "CA1812", Justification = "Instantiated via reflection.")]
-    private class Implementor : IService
+    private sealed class Implementor : IService
     {
     }
 }


### PR DESCRIPTION
- Add .NET 7 TFM.
- Update Autofac to v7.
- Update other dependencies to latest.
- Address analyzer warnings.
- Semver => v1.1.0.

I wasn't sure if the semver would be 1.1.0 since this is pretty minor for _this library_ or 2.0.0 because it brings in the behavioral breaking change from Autofac v7 (required properties getting filled in).