### PR TITLE
Update to Autofac 8, update dependencies.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,7 +34,7 @@ csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
 ; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
 
 ; Avoid this. unless absolutely necessary
 dotnet_style_qualification_for_field = false:suggestion

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
-    "formulahendry.dotnet-test-explorer",
-    "ms-dotnettools.csharp",
+    "ms-dotnettools.csdevkit",
     "editorconfig.editorconfig",
     "davidanson.vscode-markdownlint"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,10 +10,10 @@
     "netstandard",
     "xunit"
   ],
-  "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",
+  "dotnet.defaultSolution": "Autofac.Diagnostics.DotGraph.sln",
+  "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "*.resx": "$(capture).*.resx, $(capture).Designer.cs"
+    "*.resx": "$(capture).*.resx, $(capture).designer.cs, $(capture).designer.vb"
   },
-  "omnisharp.enableEditorConfigSupport": true,
-  "omnisharp.enableRoslynAnalyzers": true
+  "omnisharp.enableEditorConfigSupport": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,9 +13,6 @@
         "kind": "build"
       },
       "label": "build",
-      "presentation": {
-        "reveal": "silent"
-      },
       "problemMatcher": "$msCompile",
       "type": "shell"
     },

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Ubuntu
 
-version: '1.0.0.{build}'
+version: '2.0.0.{build}'
 
 dotnet_csproj:
-  version_prefix: '1.0.0'
+  version_prefix: '2.0.0'
   patch: true
   file: 'src\**\*.csproj'
 

--- a/build/Analyzers.ruleset
+++ b/build/Analyzers.ruleset
@@ -4,23 +4,31 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1512" Action="None" />
+    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1513" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
+    <!-- Using statements must be inside a namespace. -->
     <Rule Id="SA1200" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -2,17 +2,31 @@
 <RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+    <Rule Id="CA1031" Action="None" />
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <Rule Id="CA1040" Action="None" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
     <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
     <Rule Id="CA1816" Action="None" />
     <!-- Mark members static - test methods may not access member data but also can't be static. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Do not directly await a task - this is for libraries rather than test code. -->
+    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <Rule Id="CA1852" Action="None" />
+    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <Rule Id="CA1861" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
     <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
@@ -22,43 +36,45 @@
     <Rule Id="CA2237" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
+    <!-- Using statements must be inside a namespace. -->
     <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
+    <!-- Enforce order of class members by member type. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
+    <!-- Enforce order of class members by member visibility. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
+    <!-- Enforce order of constantand static members. -->
     <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
+    <!-- Enforce order of static vs. non-static members. -->
     <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
+    <!-- Modifiers are not ordered - .editorconfig handles this. -->
+    <Rule Id="SA1206" Action="None" />
+    <!-- Enforce order of readonly vs. non-readonly members. -->
     <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
+    <!-- Suppressions must have a justification. -->
     <Rule Id="SA1404" Action="None" />
-    <!-- Elements should be documented -->
+    <!-- Elements should be documented. -->
     <Rule Id="SA1600" Action="None" />
-    <!-- Enuemration items should be documented -->
+    <!-- Enuemration items should be documented. -->
     <Rule Id="SA1602" Action="None" />
-    <!-- Parameter documentation must be in the right order -->
+    <!-- Parameter documentation must be in the right order. -->
     <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
+    <!-- Return value must be documented. -->
     <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
+    <!-- Generic type parameters must be documented. -->
     <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
+    <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
+    <!-- Exception documentation must not be empty. -->
     <Rule Id="SA1627" Action="None" />
-    <!-- Enable XML documentation output-->
+    <!-- Enable XML documentation output. -->
     <Rule Id="SA1652" Action="None" />
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.401",
+    "version": "8.0.204",
     "rollForward": "latestFeature"
-  }
+  },
+
+  "additionalSdks": [
+    "6.0.421",
+    "7.0.408"
+  ]
 }

--- a/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
+++ b/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
@@ -13,11 +13,12 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Packaging -->
@@ -35,15 +36,18 @@
     <EmbedAllSources>true</EmbedAllSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  <!-- Disable nullability warnings in netstandard2.0 -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
+    <!-- OmniSharp/VS Code resource generation -->
+    <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
     <Using Include="System.Diagnostics.CodeAnalysis" />
   </ItemGroup>
+
+  <!-- Disable nullability warnings in netstandard2.0 -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
@@ -55,33 +59,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.4.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.CodeDom" Version="4.7.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!--
-      Magic embedded resource incantation based on https://github.com/dotnet/msbuild/issues/4751
-
-      The EmbeddedResource entry seems to add the Designer files to Compile, so
-      if you don't first remove them from Compile you get warnings about
-      double-including source.
-    -->
-    <Compile Remove="**/*.Designer.cs" />
-    <EmbeddedResource Update="TracerMessages.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>TracerMessages.Designer.cs</LastGenOutput>
-      <StronglyTypedFileName>TracerMessages.Designer.cs</StronglyTypedFileName>
+  <ItemDefinitionGroup>
+    <EmbeddedResource>
+      <Generator>MSBuild:Compile</Generator>
       <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
+      <StronglyTypedFileName>$(IntermediateOutputPath)%(Filename).Designer.cs</StronglyTypedFileName>
+      <StronglyTypedClassName>%(Filename)</StronglyTypedClassName>
+    </EmbeddedResource>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="TracerMessages.resx">
       <StronglyTypedNamespace>Autofac.Diagnostics.DotGraph</StronglyTypedNamespace>
-      <StronglyTypedClassName>TracerMessages</StronglyTypedClassName>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/test/Autofac.Diagnostics.DotGraph.Test/Autofac.Diagnostics.DotGraph.Test.csproj
+++ b/test/Autofac.Diagnostics.DotGraph.Test/Autofac.Diagnostics.DotGraph.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -9,6 +9,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -16,12 +17,8 @@
 
   <ItemGroup>
     <Using Include="System.Diagnostics.CodeAnalysis" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="Xunit" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Autofac.Diagnostics.DotGraph\Autofac.Diagnostics.DotGraph.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,21 +26,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <ProjectReference Include="..\..\src\Autofac.Diagnostics.DotGraph\Autofac.Diagnostics.DotGraph.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Diagnostics.DotGraph.Test/DotDiagnosticTracerTests.cs
+++ b/test/Autofac.Diagnostics.DotGraph.Test/DotDiagnosticTracerTests.cs
@@ -213,26 +213,28 @@ public class DotDiagnosticTracerTests
 
     private static IResolveOperation MockResolveOperation()
     {
-        return Mock.Of<IResolveOperation>();
+        return Substitute.For<IResolveOperation>();
     }
 
     private static ResolveRequest MockResolveRequest()
     {
         return new ResolveRequest(
             new TypedService(typeof(string)),
-            new ServiceRegistration(Mock.Of<IResolvePipeline>(), Mock.Of<IComponentRegistration>()),
+            new ServiceRegistration(Substitute.For<IResolvePipeline>(), Substitute.For<IComponentRegistration>()),
             Enumerable.Empty<Parameter>());
     }
 
     private static ResolveRequestContext MockResolveRequestContext()
     {
         var service = new TypedService(typeof(string));
-        var activator = Mock.Of<IInstanceActivator>(act => act.LimitType == typeof(string));
-        var registration = Mock.Of<IComponentRegistration>(reg => reg.Activator == activator);
-        return Mock.Of<ResolveRequestContext>(
-            ctx =>
-                ctx.Service == service &&
-                ctx.Registration == registration);
+        var activator = Substitute.For<IInstanceActivator>();
+        activator.LimitType.Returns(typeof(string));
+        var registration = Substitute.For<IComponentRegistration>();
+        registration.Activator.Returns(activator);
+        var context = Substitute.For<ResolveRequestContext>();
+        context.Service.Returns(service);
+        context.Registration.Returns(registration);
+        return context;
     }
 
     private class TestTracer : DotDiagnosticTracer


### PR DESCRIPTION
Resolves #14 

Updates the library to wok with Autofac 8. *This is a breaking change* due to the internals change in Autofac.

- Semver incremented from 1.0.0 to 2.0.0.
- Build metadata (`.editorconfig`, analyzer rulesets) updated to be more in sync with Autofac.
- Added target frameworks for .NET 7 and .NET 8 to match core Autofac.
- All dependencies updated to latest for best initial install experience.
- Converted Moq to NSubstitute.