### PR TITLE
Technology refresh: update dependencies and target frameworks

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <SolutionName>Autofac.Diagnostics.DotGraph</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
+++ b/src/Autofac.Diagnostics.DotGraph/Autofac.Diagnostics.DotGraph.csproj
@@ -11,7 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -57,15 +57,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Autofac" Version="9.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.CodeDom" Version="8.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.CodeDom" Version="10.0.8" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.8" />
   </ItemGroup>
 
   <ItemDefinitionGroup>


### PR DESCRIPTION
## Summary
- Update target frameworks from `net8.0;net7.0;net6.0` to `net10.0;net8.0` (keeping `netstandard2.1` and `netstandard2.0` for backward compatibility)
- Update Autofac core dependency from 8.0.0 to 9.1.0
- Update System.CodeDom from 8.0.0 to 10.0.8
- Update System.Diagnostics.DiagnosticSource from 8.0.1 to 10.0.8
- Update Microsoft.SourceLink.GitHub from 8.0.0 to 10.0.300
- Bump package version from 2.0.0 to 3.0.0

## Test plan
- [x] Build completes with zero warnings
- [x] All 19 tests pass
- [ ] CI pipeline passes on GitHub Actions